### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# cityzen-docs
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="CityZen volunteer software documentation">
+    <meta name="author" content="Rick Mason">
+    <meta http-equiv="refresh" content="0; URL=https://codeforlansing.github.io/cityzen-docs/" />
+    <title>CityZen documentation</title>
+  </head>
+
+    <body>   
+        <p>If you are not redirected <a href="https://codeforlansing.github.io/cityzen-docs/">click here</a>.</p>
+    </body>
+
+</html>


### PR DESCRIPTION
This is an updated readme.md file for Master that should redirect to the real CityZen docs which are at GitHub pages